### PR TITLE
TOURCMS-2218 add _test_url and allow constructor to override _base_url

### DIFF
--- a/spreedly.php
+++ b/spreedly.php
@@ -33,6 +33,8 @@ class Spreedly {
 	protected $_environment_key = '';
 	protected $_signing_secret = '';
 	protected $_response_format = '';
+    protected $_test_url = 'https://core-test.spreedly.com/v1';
+
 
 	/**
 	 * __construct
@@ -41,11 +43,15 @@ class Spreedly {
 	 * @param $api_access_secret
 	 * @param $environment_key
 	 */
-	public function __construct($environment_key, $api_access_secret, $signing_secret = '', $response_format = 'xml') {
+	public function __construct($environment_key, $api_access_secret, $signing_secret = '', $response_format = 'xml', $enable_test = 0) {
 		$this->_api_access_secret = $api_access_secret;
 		$this->_environment_key = $environment_key;
 		$this->_signing_secret = $signing_secret;
 		$this->_response_format = $response_format;
+
+        if($enable_test == 1) {
+            $this->set_base_url($this->_test_url);
+        }
 	}
 
 	/**


### PR DESCRIPTION
@paulslugocki  As we are only allowing customers to say whether they want to use the test URL or not I think it's best to try and keep where that is set to one place which is why I've added it to the Spreedly wrapper. 

I'm thinking possibly switch the actual URL out for a placeholder and so we can set the test URL on deploy. What do you think? 
